### PR TITLE
Fix description formatting

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-description: |
+description: >
   A full-service marine canvas and upholstery shop. Enclosures, dodgers,
   biminis, covers, cushions, canvas, and upholstery. Distinctive quality and
   style.

--- a/layouts/partials/head/meta-and-link-tags.html
+++ b/layouts/partials/head/meta-and-link-tags.html
@@ -1,13 +1,13 @@
 {{ $title := partial "page-title.html" . | safeHTML }}
 {{ $featuredImage := partial "featured-image-url.html" . }}
-{{ $description := .Description | safeHTML }}
+{{ $description := (chomp .Description) | safeHTML }}
 
 <meta charset="utf-8">
 <meta http-equiv="x-ua-compatible" content="ie=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, shrink-to-fit=no">
 
 {{ if $description }}
-  <meta name="description" content="{{ chomp $description }}">
+  <meta name="description" content="{{ $description }}">
 {{ end }}
 
 <meta property="og:type" content="{{ or .Params.ogType "website" }}">

--- a/layouts/partials/head/schema.html
+++ b/layouts/partials/head/schema.html
@@ -19,7 +19,7 @@
       "@type": "WebSite",
       "name": "{{ .Site.Title }}",
       "url": {{ .Site.BaseURL }},
-      "description": "{{ .Params.description }}",
+      "description": "{{ chomp .Params.description }}",
       "thumbnailUrl": {{ partial "logo-url.html" . }}
     }
   </script>


### PR DESCRIPTION
Ensure that the description is formatted correctly in meta tags and structured data. This fixes an issue that was causing the newline character to be printed in the description, as well as the erroneous inclusion of trailing white space.