### PR TITLE
Fix form submission format bug

### DIFF
--- a/assets/scripts/monday/monday.js
+++ b/assets/scripts/monday/monday.js
@@ -25,7 +25,7 @@ export class Monday {
   }
 
   get submissionName() {
-    return [this.LastName, this.firstName].join(", ").trim();
+    return [this.firstName, this.lastName].join(" ").trim();
   }
 
   get submissionDate() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-marine-canvas",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "BC Marine Canvas website",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix an issue where incoming form submissions would appear in Monday with formatting errors.

Instead of seeing a form submission with the name
"Burns, Monty – Website Inquiry", we started seeing ", Monty – Website Inquiry".

This commit fixes this bug, and adjusts the formatting to match the new "first, last" convention that has been adopted in most other boards within Monday.