### PR TITLE
Add Monday API version header

### DIFF
--- a/lambdas/form-submission-create.js
+++ b/lambdas/form-submission-create.js
@@ -4,6 +4,7 @@ exports.handler = (event, context, callback) => {
   const headers = {
     "Content-Type": "application/json",
     "Authorization": process.env.HUGO_MONDAY_ACCESS_TOKEN,
+    "API-Version": process.env.HUGO_MONDAY_API_VERSION,
   }
   const formSubmissionData = event.body;
   const request = {


### PR DESCRIPTION
Address a new issue with the Monday API. The API now requires all requests to set the `API-Version` header. Failure to set this header will result in a 500 server error.

This header is now set in an environment variable.