### PR TITLE
Replace Monday.com form with custom intake form

### DIFF
--- a/layouts/partials/contact-form.html
+++ b/layouts/partials/contact-form.html
@@ -1,1 +1,1 @@
-<iframe src="https://forms.monday.com/forms/embed/91d404f951f8603d0bb4e993aa33f59e" width="100%" height="1150"></iframe>
+<iframe src="https://bcmc-estimator.vercel.app/intake" width="100%" height="900" frameborder="0" scrolling="no"></iframe>

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,10 +30,10 @@ command = "yarn deploy && hugo --gc --buildDrafts --buildExpired --buildFuture -
     Content-Security-Policy = '''
       default-src 'none';
       base-uri 'self';
-      connect-src 'self' https://api.monday.com;
+      connect-src 'self' https://bcmc-estimator.vercel.app;
       font-src 'self';
-      frame-src 'self' https://forms.monday.com;
-      frame-ancestors 'self' https://forms.monday.com;
+      frame-src 'self' https://bcmc-estimator.vercel.app;
+      frame-ancestors 'self' https://bcmc-estimator.vercel.app;
       img-src 'self' data:;
       manifest-src 'self';
       script-src 'self' 'unsafe-inline';


### PR DESCRIPTION
Replace the embedded Monday.com form with a custom intake form hosted on Vercel. Update iframe attributes to remove border and scrolling, and adjust height from 1150px to 900px.